### PR TITLE
expose some superagent options as properties for UploadManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ node_modules
 # IDE
 .idea
 
-# Transformed source
-lib
-
 # npmignore
 .npmignore
 

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -1,0 +1,162 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _invariant = require('invariant');
+
+var _invariant2 = _interopRequireDefault(_invariant);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _shortid = require('shortid');
+
+var _shortid2 = _interopRequireDefault(_shortid);
+
+var _status = require('./constants/status');
+
+var _status2 = _interopRequireDefault(_status);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Receiver = function (_Component) {
+  _inherits(Receiver, _Component);
+
+  function Receiver(props) {
+    _classCallCheck(this, Receiver);
+
+    var _this = _possibleConstructorReturn(this, (Receiver.__proto__ || Object.getPrototypeOf(Receiver)).call(this, props));
+
+    _this.onDragEnter = _this.onDragEnter.bind(_this);
+    _this.onDragOver = _this.onDragOver.bind(_this);
+    _this.onDragLeave = _this.onDragLeave.bind(_this);
+    _this.onFileDrop = _this.onFileDrop.bind(_this);
+
+    // this is to monitor the hierarchy
+    // for window onDragEnter event
+    _this.state = {
+      dragLevel: 0
+    };
+    return _this;
+  }
+
+  _createClass(Receiver, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      (0, _invariant2.default)(!!window.DragEvent && !!window.DataTransfer, 'Upload end point must be provided to upload files');
+
+      window.addEventListener('dragenter', this.onDragEnter);
+      window.addEventListener('dragleave', this.onDragLeave);
+      window.addEventListener('dragover', this.onDragOver);
+      window.addEventListener('drop', this.onFileDrop);
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      window.removeEventListener('dragenter', this.onDragEnter);
+      window.removeEventListener('dragleave', this.onDragLeave);
+      window.removeEventListener('dragover', this.onDragOver);
+      window.removeEventListener('drop', this.onFileDrop);
+    }
+  }, {
+    key: 'onDragEnter',
+    value: function onDragEnter(e) {
+      var dragLevel = this.state.dragLevel + 1;
+
+      this.setState({ dragLevel: dragLevel });
+
+      if (!this.props.isOpen) {
+        this.props.onDragEnter(e);
+      }
+    }
+  }, {
+    key: 'onDragLeave',
+    value: function onDragLeave(e) {
+      var dragLevel = this.state.dragLevel - 1;
+
+      this.setState({ dragLevel: dragLevel });
+
+      if (dragLevel === 0) {
+        this.props.onDragLeave(e);
+      }
+    }
+  }, {
+    key: 'onDragOver',
+    value: function onDragOver(e) {
+      e.preventDefault();
+      this.props.onDragOver(e);
+    }
+  }, {
+    key: 'onFileDrop',
+    value: function onFileDrop(e) {
+      // eslint-disable-next-line no-param-reassign
+      e = e || window.event;
+      e.preventDefault();
+
+      var files = [];
+
+      if (!!e.dataTransfer) {
+        var fileList = e.dataTransfer.files || [];
+
+        for (var i = 0; i < fileList.length; i++) {
+          fileList[i].id = _shortid2.default.generate();
+          fileList[i].status = _status2.default.PENDING;
+          fileList[i].progress = 0;
+          fileList[i].src = null;
+          files.push(fileList[i]);
+        }
+      }
+
+      // reset drag level once dropped
+      this.setState({ dragLevel: 0 });
+
+      this.props.onFileDrop(e, files);
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          isOpen = _props.isOpen,
+          customClass = _props.customClass,
+          style = _props.style,
+          children = _props.children;
+
+
+      return isOpen ? _react2.default.createElement(
+        'div',
+        { className: (0, _classnames2.default)(customClass), style: style },
+        children
+      ) : null;
+    }
+  }]);
+
+  return Receiver;
+}(_react.Component);
+
+Receiver.propTypes = {
+  children: _react.PropTypes.oneOfType([_react.PropTypes.element, _react.PropTypes.arrayOf(_react.PropTypes.element)]),
+  customClass: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.arrayOf(_react.PropTypes.string)]),
+  isOpen: _react.PropTypes.bool.isRequired,
+  onDragEnter: _react.PropTypes.func.isRequired,
+  onDragOver: _react.PropTypes.func,
+  onDragLeave: _react.PropTypes.func.isRequired,
+  onFileDrop: _react.PropTypes.func.isRequired,
+  style: _react.PropTypes.object
+};
+
+exports.default = Receiver;

--- a/lib/UploadHandler.js
+++ b/lib/UploadHandler.js
@@ -1,0 +1,106 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _status = require('./constants/status');
+
+var _status2 = _interopRequireDefault(_status);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var debug = require('debug')('react-file-upload:UploadHandler');
+
+var UploadHandler = function (_Component) {
+  _inherits(UploadHandler, _Component);
+
+  function UploadHandler() {
+    _classCallCheck(this, UploadHandler);
+
+    return _possibleConstructorReturn(this, (UploadHandler.__proto__ || Object.getPrototypeOf(UploadHandler)).apply(this, arguments));
+  }
+
+  _createClass(UploadHandler, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var _props = this.props,
+          file = _props.file,
+          upload = _props.upload,
+          autoStart = _props.autoStart;
+
+
+      if (file.status === _status2.default.PENDING && autoStart) {
+        debug('autoStart in on, calling upload()');
+        upload(file);
+      }
+    }
+  }, {
+    key: 'getStatusString',
+    value: function getStatusString(status) {
+      switch (status) {
+        case -1:
+          return 'failed';
+
+        case 0:
+          return 'pending';
+
+        case 1:
+          return 'uploading';
+
+        case 2:
+          return 'uploaded';
+
+        default:
+          return '';
+      }
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props2 = this.props,
+          component = _props2.component,
+          key = _props2.key,
+          customClass = _props2.customClass,
+          style = _props2.style;
+
+
+      return _react2.default.createElement(component, { key: key, className: (0, _classnames2.default)(customClass), style: style }, this.props.children);
+    }
+  }]);
+
+  return UploadHandler;
+}(_react.Component);
+
+UploadHandler.propTypes = {
+  autoStart: _react.PropTypes.bool,
+  children: _react.PropTypes.oneOfType([_react.PropTypes.element, _react.PropTypes.arrayOf(_react.PropTypes.element)]),
+  component: _react.PropTypes.string.isRequired,
+  customClass: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.arrayOf(_react.PropTypes.string)]),
+  file: _react.PropTypes.object.isRequired,
+  key: _react.PropTypes.string,
+  style: _react.PropTypes.object,
+  upload: _react.PropTypes.func
+};
+
+UploadHandler.defaultProps = {
+  component: 'li'
+};
+
+exports.default = UploadHandler;

--- a/lib/UploadManager.js
+++ b/lib/UploadManager.js
@@ -1,40 +1,40 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _invariant = require('invariant');
+var _invariant = require("invariant");
 
 var _invariant2 = _interopRequireDefault(_invariant);
 
-var _classnames = require('classnames');
+var _classnames = require("classnames");
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var _assign = require('lodash/assign');
+var _assign = require("lodash/assign");
 
 var _assign2 = _interopRequireDefault(_assign);
 
-var _bindKey = require('lodash/bindKey');
+var _bindKey = require("lodash/bindKey");
 
 var _bindKey2 = _interopRequireDefault(_bindKey);
 
-var _clone = require('lodash/clone');
+var _clone = require("lodash/clone");
 
 var _clone2 = _interopRequireDefault(_clone);
 
-var _superagent = require('superagent');
+var _superagent = require("superagent");
 
 var _superagent2 = _interopRequireDefault(_superagent);
 
-var _status = require('./constants/status');
+var _status = require("./constants/status");
 
 var _status2 = _interopRequireDefault(_status);
 
@@ -49,132 +49,132 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var debug = require('debug')('react-file-upload:UploadManager');
 
 var UploadManager = function (_Component) {
-  _inherits(UploadManager, _Component);
+    _inherits(UploadManager, _Component);
 
-  function UploadManager(props) {
-    _classCallCheck(this, UploadManager);
+    function UploadManager(props) {
+        _classCallCheck(this, UploadManager);
 
-    var _this = _possibleConstructorReturn(this, (UploadManager.__proto__ || Object.getPrototypeOf(UploadManager)).call(this, props));
+        var _this = _possibleConstructorReturn(this, (UploadManager.__proto__ || Object.getPrototypeOf(UploadManager)).call(this, props));
 
-    _this.upload = _this.upload.bind(_this);
-    return _this;
-  }
-
-  _createClass(UploadManager, [{
-    key: 'componentDidMount',
-    value: function componentDidMount() {
-      (0, _invariant2.default)(!!this.props.uploadUrl, 'Upload end point must be provided to upload files');
-
-      (0, _invariant2.default)(!!this.props.onUploadEnd, 'onUploadEnd function must be provided');
+        _this.upload = _this.upload.bind(_this);
+        return _this;
     }
-  }, {
-    key: 'upload',
-    value: function upload(url, file) {
-      var _props = this.props,
-          onUploadStart = _props.onUploadStart,
-          onUploadEnd = _props.onUploadEnd,
-          onUploadProgress = _props.onUploadProgress,
-          uploadErrorHandler = _props.uploadErrorHandler,
-          _props$uploadHeader = _props.uploadHeader,
-          uploadHeader = _props$uploadHeader === undefined ? {} : _props$uploadHeader,
-          method = _props.method;
 
+    _createClass(UploadManager, [{
+        key: "componentDidMount",
+        value: function componentDidMount() {
+            (0, _invariant2.default)(!!this.props.uploadUrl, 'Upload end point must be provided to upload files');
 
-      if (typeof onUploadStart === 'function') {
-        onUploadStart((0, _assign2.default)(file, { status: _status2.default.UPLOADING }));
-      }
-
-      var formData = new FormData();
-      formData.append('file', file);
-
-      debug('start uploading file#' + file.id + ' to ' + url, file);
-
-      _superagent2.default[method.toLowerCase()](url).accept('application/json').set(uploadHeader).send(formData).on('progress', function (_ref) {
-        var percent = _ref.percent;
-
-        if (typeof onUploadProgress === 'function') {
-          onUploadProgress((0, _assign2.default)(file, {
-            progress: percent,
-            status: _status2.default.UPLOADING
-          }));
+            (0, _invariant2.default)(!!this.props.onUploadEnd, 'onUploadEnd function must be provided');
         }
-      }).end(function (err, res) {
-        var _uploadErrorHandler = uploadErrorHandler(err, res),
-            error = _uploadErrorHandler.error,
-            result = _uploadErrorHandler.result;
+    }, {
+        key: "upload",
+        value: function upload(url, file) {
+            var _props = this.props,
+                onUploadStart = _props.onUploadStart,
+                onUploadEnd = _props.onUploadEnd,
+                onUploadProgress = _props.onUploadProgress,
+                uploadErrorHandler = _props.uploadErrorHandler,
+                _props$uploadHeader = _props.uploadHeader,
+                uploadHeader = _props$uploadHeader === undefined ? {} : _props$uploadHeader,
+                method = _props.method,
+                accept = _props.accept;
 
-        if (error) {
-          debug('failed to upload file', error);
 
-          if (typeof onUploadEnd === 'function') {
-            onUploadEnd((0, _assign2.default)(file, { error: error, status: _status2.default.FAILED }));
-          }
+            if (typeof onUploadStart === 'function') {
+                onUploadStart((0, _assign2.default)(file, { status: _status2.default.UPLOADING }));
+            }
 
-          return;
+            debug("start uploading file#" + file.id + " to " + url, file);
+
+            _superagent2.default[method.toLowerCase()](url).accept(accept).set(uploadHeader).type(file.type).send(file).on('progress', function (_ref) {
+                var percent = _ref.percent;
+
+                if (typeof onUploadProgress === 'function') {
+                    onUploadProgress((0, _assign2.default)(file, {
+                        progress: percent,
+                        status: _status2.default.UPLOADING
+                    }));
+                }
+            }).end(function (err, res) {
+                var _uploadErrorHandler = uploadErrorHandler(err, res),
+                    error = _uploadErrorHandler.error,
+                    result = _uploadErrorHandler.result;
+
+                if (error) {
+                    debug('failed to upload file', error);
+
+                    if (typeof onUploadEnd === 'function') {
+                        onUploadEnd((0, _assign2.default)(file, { error: error, status: _status2.default.FAILED }));
+                    }
+
+                    return;
+                }
+
+                debug('succeeded to upload file', res);
+
+                if (typeof onUploadEnd === 'function') {
+                    onUploadEnd((0, _assign2.default)(file, { result: result, status: _status2.default.UPLOADED }));
+                }
+            });
         }
+    }, {
+        key: "render",
+        value: function render() {
+            var _this2 = this;
 
-        debug('succeeded to upload file', res);
+            var _props2 = this.props,
+                component = _props2.component,
+                customClass = _props2.customClass,
+                style = _props2.style,
+                children = _props2.children,
+                uploadUrl = _props2.uploadUrl;
 
-        if (typeof onUploadEnd === 'function') {
-          onUploadEnd((0, _assign2.default)(file, { result: result, status: _status2.default.UPLOADED }));
+
+            return _react2.default.createElement(component, { className: (0, _classnames2.default)(customClass), style: style }, _react2.default.Children.map(children, function (child) {
+                return (0, _react.cloneElement)(child, (0, _assign2.default)({
+                    upload: (0, _bindKey2.default)(_this2, 'upload', uploadUrl, child.props.file)
+                }, child.props));
+            }));
         }
-      });
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      var _this2 = this;
+    }]);
 
-      var _props2 = this.props,
-          component = _props2.component,
-          customClass = _props2.customClass,
-          style = _props2.style,
-          children = _props2.children,
-          uploadUrl = _props2.uploadUrl;
-
-
-      return _react2.default.createElement(component, { className: (0, _classnames2.default)(customClass), style: style }, _react2.default.Children.map(children, function (child) {
-        return (0, _react.cloneElement)(child, (0, _assign2.default)({
-          upload: (0, _bindKey2.default)(_this2, 'upload', uploadUrl, child.props.file)
-        }, child.props));
-      }));
-    }
-  }]);
-
-  return UploadManager;
+    return UploadManager;
 }(_react.Component);
 
 UploadManager.propTypes = {
-  children: _react.PropTypes.oneOfType([_react.PropTypes.element, _react.PropTypes.arrayOf(_react.PropTypes.element)]),
-  component: _react.PropTypes.string.isRequired,
-  customClass: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.arrayOf(_react.PropTypes.string)]),
-  onUploadStart: _react.PropTypes.func,
-  onUploadProgress: _react.PropTypes.func,
-  onUploadEnd: _react.PropTypes.func.isRequired,
-  style: _react.PropTypes.object,
-  uploadErrorHandler: _react.PropTypes.func.isRequired,
-  uploadUrl: _react.PropTypes.string.isRequired,
-  uploadHeader: _react.PropTypes.object,
-  method: _react.PropTypes.string
+    children: _react.PropTypes.oneOfType([_react.PropTypes.element, _react.PropTypes.arrayOf(_react.PropTypes.element)]),
+    component: _react.PropTypes.string.isRequired,
+    customClass: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.arrayOf(_react.PropTypes.string)]),
+    onUploadStart: _react.PropTypes.func,
+    onUploadProgress: _react.PropTypes.func,
+    onUploadEnd: _react.PropTypes.func.isRequired,
+    style: _react.PropTypes.object,
+    uploadErrorHandler: _react.PropTypes.func.isRequired,
+    uploadUrl: _react.PropTypes.string.isRequired,
+    uploadHeader: _react.PropTypes.object,
+    method: _react.PropTypes.string,
+    accept: _react.PropTypes.string
 };
 
 UploadManager.defaultProps = {
-  component: 'ul',
-  method: 'post',
-  uploadErrorHandler: function uploadErrorHandler(err, res) {
-    var error = null;
-    var body = (0, _clone2.default)(res.body);
+    component: 'ul',
+    method: 'post',
+    accept: 'application/json',
+    uploadErrorHandler: function uploadErrorHandler(err, res) {
+        var error = null;
+        var body = (0, _clone2.default)(res.body);
 
-    if (err) {
-      error = err.message;
-    } else if (body && body.errors) {
-      error = body.errors;
+        if (err) {
+            error = err.message;
+        } else if (body && body.errors) {
+            error = body.errors;
+        }
+
+        delete body.errors;
+
+        return { error: error, result: body };
     }
-
-    delete body.errors;
-
-    return { error: error, result: body };
-  }
 };
 
 exports.default = UploadManager;

--- a/lib/UploadManager.js
+++ b/lib/UploadManager.js
@@ -78,16 +78,25 @@ var UploadManager = function (_Component) {
                 _props$uploadHeader = _props.uploadHeader,
                 uploadHeader = _props$uploadHeader === undefined ? {} : _props$uploadHeader,
                 method = _props.method,
-                accept = _props.accept;
+                accept = _props.accept,
+                field = _props.field;
 
 
             if (typeof onUploadStart === 'function') {
                 onUploadStart((0, _assign2.default)(file, { status: _status2.default.UPLOADING }));
             }
 
+            var data = void 0;
+            if (!!field) {
+                var formData = new FormData();
+                formData.append(field, file);
+                data = formData;
+            } else {
+                data = file;
+            }
             debug("start uploading file#" + file.id + " to " + url, file);
 
-            _superagent2.default[method.toLowerCase()](url).accept(accept).set(uploadHeader).type(file.type).send(file).on('progress', function (_ref) {
+            _superagent2.default[method.toLowerCase()](url).accept(accept).set(uploadHeader).type(file.type).send(data).on('progress', function (_ref) {
                 var percent = _ref.percent;
 
                 if (typeof onUploadProgress === 'function') {
@@ -154,13 +163,15 @@ UploadManager.propTypes = {
     uploadUrl: _react.PropTypes.string.isRequired,
     uploadHeader: _react.PropTypes.object,
     method: _react.PropTypes.string,
-    accept: _react.PropTypes.string
+    accept: _react.PropTypes.string,
+    field: _react.PropTypes.string
 };
 
 UploadManager.defaultProps = {
     component: 'ul',
     method: 'post',
     accept: 'application/json',
+    field: 'file',
     uploadErrorHandler: function uploadErrorHandler(err, res) {
         var error = null;
         var body = (0, _clone2.default)(res.body);

--- a/lib/UploadManager.js
+++ b/lib/UploadManager.js
@@ -1,0 +1,180 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _invariant = require('invariant');
+
+var _invariant2 = _interopRequireDefault(_invariant);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _assign = require('lodash/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _bindKey = require('lodash/bindKey');
+
+var _bindKey2 = _interopRequireDefault(_bindKey);
+
+var _clone = require('lodash/clone');
+
+var _clone2 = _interopRequireDefault(_clone);
+
+var _superagent = require('superagent');
+
+var _superagent2 = _interopRequireDefault(_superagent);
+
+var _status = require('./constants/status');
+
+var _status2 = _interopRequireDefault(_status);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var debug = require('debug')('react-file-upload:UploadManager');
+
+var UploadManager = function (_Component) {
+  _inherits(UploadManager, _Component);
+
+  function UploadManager(props) {
+    _classCallCheck(this, UploadManager);
+
+    var _this = _possibleConstructorReturn(this, (UploadManager.__proto__ || Object.getPrototypeOf(UploadManager)).call(this, props));
+
+    _this.upload = _this.upload.bind(_this);
+    return _this;
+  }
+
+  _createClass(UploadManager, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      (0, _invariant2.default)(!!this.props.uploadUrl, 'Upload end point must be provided to upload files');
+
+      (0, _invariant2.default)(!!this.props.onUploadEnd, 'onUploadEnd function must be provided');
+    }
+  }, {
+    key: 'upload',
+    value: function upload(url, file) {
+      var _props = this.props,
+          onUploadStart = _props.onUploadStart,
+          onUploadEnd = _props.onUploadEnd,
+          onUploadProgress = _props.onUploadProgress,
+          uploadErrorHandler = _props.uploadErrorHandler,
+          _props$uploadHeader = _props.uploadHeader,
+          uploadHeader = _props$uploadHeader === undefined ? {} : _props$uploadHeader,
+          method = _props.method;
+
+
+      if (typeof onUploadStart === 'function') {
+        onUploadStart((0, _assign2.default)(file, { status: _status2.default.UPLOADING }));
+      }
+
+      var formData = new FormData();
+      formData.append('file', file);
+
+      debug('start uploading file#' + file.id + ' to ' + url, file);
+
+      _superagent2.default[method.toLowerCase()](url).accept('application/json').set(uploadHeader).send(formData).on('progress', function (_ref) {
+        var percent = _ref.percent;
+
+        if (typeof onUploadProgress === 'function') {
+          onUploadProgress((0, _assign2.default)(file, {
+            progress: percent,
+            status: _status2.default.UPLOADING
+          }));
+        }
+      }).end(function (err, res) {
+        var _uploadErrorHandler = uploadErrorHandler(err, res),
+            error = _uploadErrorHandler.error,
+            result = _uploadErrorHandler.result;
+
+        if (error) {
+          debug('failed to upload file', error);
+
+          if (typeof onUploadEnd === 'function') {
+            onUploadEnd((0, _assign2.default)(file, { error: error, status: _status2.default.FAILED }));
+          }
+
+          return;
+        }
+
+        debug('succeeded to upload file', res);
+
+        if (typeof onUploadEnd === 'function') {
+          onUploadEnd((0, _assign2.default)(file, { result: result, status: _status2.default.UPLOADED }));
+        }
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
+
+      var _props2 = this.props,
+          component = _props2.component,
+          customClass = _props2.customClass,
+          style = _props2.style,
+          children = _props2.children,
+          uploadUrl = _props2.uploadUrl;
+
+
+      return _react2.default.createElement(component, { className: (0, _classnames2.default)(customClass), style: style }, _react2.default.Children.map(children, function (child) {
+        return (0, _react.cloneElement)(child, (0, _assign2.default)({
+          upload: (0, _bindKey2.default)(_this2, 'upload', uploadUrl, child.props.file)
+        }, child.props));
+      }));
+    }
+  }]);
+
+  return UploadManager;
+}(_react.Component);
+
+UploadManager.propTypes = {
+  children: _react.PropTypes.oneOfType([_react.PropTypes.element, _react.PropTypes.arrayOf(_react.PropTypes.element)]),
+  component: _react.PropTypes.string.isRequired,
+  customClass: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.arrayOf(_react.PropTypes.string)]),
+  onUploadStart: _react.PropTypes.func,
+  onUploadProgress: _react.PropTypes.func,
+  onUploadEnd: _react.PropTypes.func.isRequired,
+  style: _react.PropTypes.object,
+  uploadErrorHandler: _react.PropTypes.func.isRequired,
+  uploadUrl: _react.PropTypes.string.isRequired,
+  uploadHeader: _react.PropTypes.object,
+  method: _react.PropTypes.string
+};
+
+UploadManager.defaultProps = {
+  component: 'ul',
+  method: 'post',
+  uploadErrorHandler: function uploadErrorHandler(err, res) {
+    var error = null;
+    var body = (0, _clone2.default)(res.body);
+
+    if (err) {
+      error = err.message;
+    } else if (body && body.errors) {
+      error = body.errors;
+    }
+
+    delete body.errors;
+
+    return { error: error, result: body };
+  }
+};
+
+exports.default = UploadManager;

--- a/lib/UploadManager.js
+++ b/lib/UploadManager.js
@@ -86,17 +86,25 @@ var UploadManager = function (_Component) {
                 onUploadStart((0, _assign2.default)(file, { status: _status2.default.UPLOADING }));
             }
 
-            var data = void 0;
+            var data = void 0,
+                type = void 0;
             if (!!field) {
                 var formData = new FormData();
                 formData.append(field, file);
                 data = formData;
             } else {
                 data = file;
+                type = file.type;
             }
             debug("start uploading file#" + file.id + " to " + url, file);
 
-            _superagent2.default[method.toLowerCase()](url).accept(accept).set(uploadHeader).type(file.type).send(data).on('progress', function (_ref) {
+            var req = _superagent2.default[method.toLowerCase()](url).accept(accept).set(uploadHeader);
+
+            if (!!type) {
+                req = req.type(file.type);
+            }
+
+            req.send(data).on('progress', function (_ref) {
                 var percent = _ref.percent;
 
                 if (typeof onUploadProgress === 'function') {

--- a/lib/__tests__/Receiver-test.js
+++ b/lib/__tests__/Receiver-test.js
@@ -1,0 +1,331 @@
+'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _jsdom = require('jsdom');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint-disable no-undef, max-len */
+jest.dontMock('../Receiver');
+jest.dontMock('../index');
+jest.dontMock('classnames');
+
+var FileUploader = require('../index');
+var PENDING = FileUploader.status.PENDING;
+
+var Receiver = FileUploader.Receiver;
+
+var createComponent = function createComponent(onDragEnter, onDragOver, onDragLeave, onFileDrop) {
+  return _react2.default.createElement(Receiver, {
+    onDragEnter: onDragEnter,
+    onDragOver: onDragOver,
+    onDragLeave: onDragLeave,
+    onFileDrop: onFileDrop
+  });
+};
+
+// eslint-disable-next-line react/prefer-es6-class
+var createTemplate = function createTemplate(initialState, props, Component) {
+  return _react2.default.createClass({
+    getInitialState: function getInitialState() {
+      return initialState;
+    },
+    render: function render() {
+      return _react2.default.createElement(
+        Component.type,
+        _extends({
+          ref: 'receiver',
+          isOpen: this.state.isOpen,
+          files: this.state.files
+        }, props, Component.props),
+        _react2.default.createElement(
+          'h1',
+          null,
+          'Test'
+        )
+      );
+    }
+  });
+};
+
+describe('Receiver', function () {
+  beforeEach(function setting() {
+    global.document = (0, _jsdom.jsdom)();
+    global.window = document.parentWindow;
+
+    var testFile = {
+      lastModified: 1465229147840,
+      lastModifiedDate: 'Tue Jun 07 2016 00:05:47 GMT+0800 (HKT)',
+      name: 'test.jpg',
+      size: 1024,
+      type: 'image/jpg',
+      webkitRelativePath: ''
+    };
+    var files = [testFile];
+
+    var mockDT = {
+      files: files,
+      setData: jest.genMockFunction()
+    };
+
+    this.stringClass = 'receiver';
+    this.arrayClass = ['react', 'receiver'];
+
+    this.dragEnterEvent = document.createEvent('HTMLEvents');
+    this.dragEnterEvent.initEvent('dragenter', false, true);
+
+    this.dragOverEvent = document.createEvent('HTMLEvents');
+    this.dragOverEvent.initEvent('dragover', false, true);
+    this.dragOverEvent.preventDefault = jest.genMockFn();
+
+    this.dragLeaveEvent = document.createEvent('HTMLEvents');
+    this.dragLeaveEvent.initEvent('dragleave', false, true);
+
+    this.dropEvent = document.createEvent('HTMLEvents');
+    this.dropEvent.initEvent('drop', false, true);
+    this.dropEvent.preventDefault = jest.genMockFn();
+    this.dropEvent.dataTransfer = mockDT;
+  });
+
+  describe('state of dragLevel', function () {
+    beforeEach(function setting() {
+      var onDragEnter = jest.genMockFn();
+      var onDragOver = jest.genMockFn();
+      var onDragLeave = jest.genMockFn();
+      var onFileDrop = jest.genMockFn();
+
+      this.onDragEnter = onDragEnter;
+      this.onDragOver = onDragOver;
+      this.onDragLeave = onDragLeave;
+      this.onFileDrop = onFileDrop;
+
+      var Component = createComponent(onDragEnter, onDragOver, onDragLeave, onFileDrop);
+      var template = createTemplate({ isOpen: false, files: [] }, {}, Component);
+
+      this.createTestParent = _react2.default.createFactory(template);
+      this.ParentComponent = this.createTestParent();
+      this.container = document.createElement('div');
+      this.instance = _reactDom2.default.render(this.ParentComponent, this.container);
+      this.receiver = this.instance.refs.receiver;
+    });
+
+    it('should increase state of dragLevel by 1 with dragEnter event', function test() {
+      var oldDragLevel = this.receiver.state.dragLevel;
+      window.dispatchEvent(this.dragEnterEvent);
+      var newDragLevel = this.receiver.state.dragLevel;
+      expect(newDragLevel).toEqual(oldDragLevel + 1);
+    });
+
+    it('should call onDragEnter with dragEnter event if isOpen is false', function test() {
+      window.dispatchEvent(this.dragEnterEvent);
+      expect(this.onDragEnter).toBeCalled();
+    });
+
+    it('should not call onDragEnter with dragEnter event if isOpen is true', function test() {
+      this.instance.setState({ isOpen: true });
+      window.dispatchEvent(this.dragEnterEvent);
+      expect(this.onDragEnter).not.toBeCalled();
+    });
+
+    it('should call event.preventDefault with dragOver event', function test() {
+      window.dispatchEvent(this.dragOverEvent);
+      expect(this.dragOverEvent.preventDefault).toBeCalled();
+    });
+
+    it('should call onDragOver with dragOver event', function test() {
+      window.dispatchEvent(this.dragOverEvent);
+      expect(this.onDragOver).toBeCalled();
+    });
+
+    it('should decrease state of dragLevel by 1 with dragLeave event', function test() {
+      var oldDragLevel = this.receiver.state.dragLevel;
+      window.dispatchEvent(this.dragEnterEvent);
+      var newDragLevel = this.receiver.state.dragLevel;
+      expect(newDragLevel).toEqual(oldDragLevel + 1);
+
+      window.dispatchEvent(this.dragLeaveEvent);
+      var finalDragLevel = this.receiver.state.dragLevel;
+      expect(finalDragLevel).toEqual(newDragLevel - 1);
+      expect(this.onDragLeave).toBeCalled();
+    });
+
+    it('should call onDragLeave if state of dragLevel is not 0', function test() {
+      var oldDragLevel = this.receiver.state.dragLevel;
+      window.dispatchEvent(this.dragEnterEvent);
+      var newDragLevel = this.receiver.state.dragLevel;
+      expect(newDragLevel).toEqual(oldDragLevel + 1);
+
+      window.dispatchEvent(this.dragEnterEvent);
+      var newerDragLevel = this.receiver.state.dragLevel;
+      expect(newerDragLevel).toEqual(newDragLevel + 1);
+
+      window.dispatchEvent(this.dragLeaveEvent);
+      var finalDragLevel = this.receiver.state.dragLevel;
+      expect(finalDragLevel).toEqual(newerDragLevel - 1);
+      expect(this.onDragLeave).not.toBeCalled();
+
+      window.dispatchEvent(this.dragLeaveEvent);
+      var endDragLevel = this.receiver.state.dragLevel;
+      expect(endDragLevel).toEqual(finalDragLevel - 1);
+      expect(this.onDragLeave).toBeCalled();
+    });
+
+    it('should call event.preventDefault with drop event', function test() {
+      window.dispatchEvent(this.dropEvent);
+      // eslint-disable-next-line no-undef
+      expect(this.dropEvent.preventDefault).toBeCalled();
+    });
+
+    it('should call onFileDrop with drop event', function test() {
+      window.dispatchEvent(this.dropEvent);
+      expect(this.onFileDrop).toBeCalled();
+    });
+
+    it('should set state of dragLevel to 0 with dragEnter event', function test() {
+      var oldDragLevel = this.receiver.state.dragLevel;
+      window.dispatchEvent(this.dragEnterEvent);
+      var newDragLevel = this.receiver.state.dragLevel;
+      expect(newDragLevel).toEqual(oldDragLevel + 1);
+
+      window.dispatchEvent(this.dropEvent);
+      var finalDragLevel = this.receiver.state.dragLevel;
+      expect(finalDragLevel).toEqual(0);
+    });
+
+    it('should not call any callback after Receiver did unmount', function test() {
+      _reactDom2.default.unmountComponentAtNode(this.container);
+      window.dispatchEvent(this.dragEnterEvent);
+      expect(this.onDragEnter).not.toBeCalled();
+
+      window.dispatchEvent(this.dragOverEvent);
+      expect(this.onDragOver).not.toBeCalled();
+
+      window.dispatchEvent(this.dragLeaveEvent);
+      expect(this.onDragLeave).not.toBeCalled();
+
+      window.dispatchEvent(this.dropEvent);
+      expect(this.onFileDrop).not.toBeCalled();
+    });
+  });
+
+  describe('callbacks and callback arguments', function () {
+    beforeEach(function setting() {
+      var onDragEnter = function onDragEnter(e) {
+        expect(e.type).toBe('dragenter');
+      };
+      var onDragOver = function onDragOver(e) {
+        expect(e.type).toBe('dragover');
+      };
+      var onDragLeave = function onDragLeave(e) {
+        expect(e.type).toBe('dragleave');
+      };
+      var onFileDrop = function onFileDrop(e, _files) {
+        expect(e.type).toBe('drop');
+        var file = _files[0];
+        expect(file.lastModified).toBe(testFile.lastModified);
+        expect(file.lastModifiedDate).toBe(testFile.lastModifiedDate);
+        expect(file.name).toBe(testFile.name);
+        expect(file.size).toBe(testFile.size);
+        expect(file.type).toBe(testFile.type);
+        expect(file.webkitRelativePath).toBe(testFile.webkitRelativePath);
+        expect(file.status).toBe(PENDING);
+        expect(file.progress).toBe(0);
+        expect(file.src).toBe(null);
+      };
+
+      this.onDragEnter = onDragEnter;
+      this.onDragOver = onDragOver;
+      this.onDragLeave = onDragLeave;
+      this.onFileDrop = onFileDrop;
+
+      var Component = createComponent(onDragEnter, onDragOver, onDragLeave, onFileDrop);
+      var template = createTemplate({ isOpen: false, files: [] }, {}, Component);
+
+      this.createTestParent = _react2.default.createFactory(template);
+      this.ParentComponent = this.createTestParent();
+      this.container = document.createElement('div');
+      this.instance = _reactDom2.default.render(this.ParentComponent, this.container);
+      this.receiver = this.instance.refs.receiver;
+    });
+
+    it('should execute the onDragEnter callback with a DragEvent with type `dragenter` as argument', function test() {
+      window.dispatchEvent(this.dragEnterEvent);
+    });
+
+    it('should execute the onDragOver callback with a DragEvent with type `dragover` as argument', function test() {
+      window.dispatchEvent(this.dragOverEvent);
+    });
+
+    it('should execute the onDragLeave callback with a DragEvent with type `dragleave` as argument', function test() {
+      window.dispatchEvent(this.dragLeaveEvent);
+    });
+
+    it('should execute the onFileDrop callback with a DragEvent with type `drop` as argument', function test() {
+      window.dispatchEvent(this.dropEvent);
+    });
+  });
+
+  describe('#render', function () {
+    beforeEach(function setting() {
+      var Component = createComponent();
+      var template = createTemplate({ isOpen: false, files: [] }, {}, Component);
+
+      this.createTestParent = _react2.default.createFactory(template);
+      this.ParentComponent = this.createTestParent();
+      this.container = document.createElement('div');
+      this.instance = _reactDom2.default.render(this.ParentComponent, this.container);
+      this.receiver = this.instance.refs.receiver;
+    });
+
+    it('should render nothing if isOpen is false', function test() {
+      var receiver = _reactDom2.default.findDOMNode(this.receiver);
+      expect(receiver).toBeNull();
+      this.instance.setState({ isOpen: true });
+    });
+
+    it('should render a div wrapper with children if isOpen is true', function test() {
+      this.instance.setState({ isOpen: true });
+      var receiver = _reactDom2.default.findDOMNode(this.receiver);
+      expect(receiver).toEqual(jasmine.any(HTMLDivElement));
+      expect(receiver.firstElementChild).toEqual(jasmine.any(HTMLHeadingElement));
+    });
+
+    it('should render a div wrapper with customClass in string', function test() {
+      var Component = createComponent();
+      var template = createTemplate({ isOpen: true, files: [] }, { customClass: this.stringClass }, Component);
+
+      this.createTestParent = _react2.default.createFactory(template);
+      this.ParentComponent = this.createTestParent();
+      this.container = document.createElement('div');
+      this.instance = _reactDom2.default.render(this.ParentComponent, this.container);
+      this.receiver = this.instance.refs.receiver;
+
+      var receiver = _reactDom2.default.findDOMNode(this.receiver);
+      expect(receiver.className).toEqual(this.stringClass);
+    });
+
+    it('should render a div wrapper with customClass in array', function test() {
+      var Component = createComponent();
+      var template = createTemplate({ isOpen: true, files: [] }, { customClass: this.arrayClass }, Component);
+
+      this.createTestParent = _react2.default.createFactory(template);
+      this.ParentComponent = this.createTestParent();
+      this.container = document.createElement('div');
+      this.instance = _reactDom2.default.render(this.ParentComponent, this.container);
+      this.receiver = this.instance.refs.receiver;
+
+      var receiver = _reactDom2.default.findDOMNode(this.receiver);
+      expect(receiver.className).toEqual(this.arrayClass.join(' '));
+    });
+  });
+});
+/* eslint-enable no-undef */

--- a/lib/__tests__/UploadManager-test.js
+++ b/lib/__tests__/UploadManager-test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _jsdom = require('jsdom');
+
+var _nock = require('nock');
+
+var _nock2 = _interopRequireDefault(_nock);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint-disable no-undef, max-len */
+jest.dontMock('../UploadManager');
+jest.dontMock('../index');
+jest.dontMock('classnames');
+jest.dontMock('lodash');
+
+var FileUploader = require('../index');
+var UploadManager = FileUploader.UploadManager;
+var uploadStatus = FileUploader.status;
+
+describe('UploadManager', function () {
+  beforeEach(function setting() {
+    global.document = (0, _jsdom.jsdom)();
+    global.window = document.parentWindow;
+
+    this.stringClass = 'receiver';
+    this.arrayClass = ['react', 'receiver'];
+    this.style = { display: 'block' };
+    this.uploadPath = 'http://localhost:3000/api/upload';
+    this.onUploadStart = jest.fn();
+    this.onUploadProgress = jest.fn();
+    this.onUploadEnd = jest.fn();
+
+    this.children = _react2.default.createElement(
+      'p',
+      null,
+      'children'
+    );
+    this.container = document.createElement('div');
+    this.instance = _reactDom2.default.render(_react2.default.createElement(
+      UploadManager,
+      {
+        uploadUrl: this.uploadPath,
+        onUploadEnd: this.onUploadEnd
+      },
+      this.children
+    ), this.container);
+  });
+
+  afterEach(function setting() {
+    this.container = null;
+    this.instance = null;
+  });
+
+  describe('#render()', function () {
+    it('should render ul element by default', function test() {
+      var node = _reactDom2.default.findDOMNode(this.instance);
+      expect(node).toEqual(jasmine.any(HTMLUListElement));
+      expect(node.firstElementChild).toEqual(jasmine.any(HTMLParagraphElement));
+    });
+
+    it('should render wrapper element according to component props', function test() {
+      this.instance = _reactDom2.default.render(_react2.default.createElement(
+        UploadManager,
+        {
+          component: 'div',
+          uploadUrl: this.uploadPath,
+          onUploadEnd: this.onUploadEnd
+        },
+        this.children
+      ), this.container);
+      var node = _reactDom2.default.findDOMNode(this.instance);
+      expect(node).toEqual(jasmine.any(HTMLDivElement));
+    });
+
+    it('should render a wrapper with customClass in string', function test() {
+      this.instance = _reactDom2.default.render(_react2.default.createElement(
+        UploadManager,
+        {
+          component: 'div',
+          customClass: this.stringClass,
+          style: this.style,
+          uploadUrl: this.uploadPath,
+          onUploadEnd: this.onUploadEnd
+        },
+        this.children
+      ), this.container);
+      var node = _reactDom2.default.findDOMNode(this.instance);
+      expect(node.className).toEqual(this.stringClass);
+    });
+
+    it('should render a wrapper with customClass in array', function test() {
+      this.instance = _reactDom2.default.render(_react2.default.createElement(
+        UploadManager,
+        {
+          component: 'div',
+          customClass: this.arrayClass,
+          style: this.style,
+          uploadUrl: this.uploadPath,
+          onUploadEnd: this.onUploadEnd
+        },
+        this.children
+      ), this.container);
+      var node = _reactDom2.default.findDOMNode(this.instance);
+      expect(node.className).toEqual(this.arrayClass.join(' '));
+    });
+  });
+
+  describe('#uploadErrorHandler()', function () {
+    beforeEach(function setting() {
+      this.err = new Error('not found');
+      this.errorResponse = { body: { success: false, errors: { message: 'not found' } } };
+      this.successResponse = { body: { success: true } };
+      this.errorHandler = this.instance.props.uploadErrorHandler;
+    });
+
+    it('should return an object contains key of `error` and `result`', function test() {
+      var result = this.errorHandler(null, this.successResponse);
+      expect(result.error).toBeNull();
+      expect(result.result).toEqual(this.successResponse.body);
+    });
+
+    it('should return an object with key of `error` with value equals to the first argument if it is not empty', function test() {
+      var result = this.errorHandler(this.err, this.successResponse);
+      expect(result.error).toEqual(this.err.message);
+      expect(result.result).toEqual(this.successResponse.body);
+    });
+
+    it('should return an object with key of `error` with value equals to the value of `body.error` of the second argument if it is not empty', function test() {
+      var result = this.errorHandler(null, this.errorResponse);
+      expect(result.error).toEqual(this.errorResponse.body.errors);
+      delete this.errorResponse.body.errors;
+      expect(result.result).toEqual(this.errorResponse.body);
+    });
+  });
+
+  describe('#upload()', function () {
+    beforeEach(function setting() {
+      (0, _nock2.default)('http://localhost:3000').filteringRequestBody(function () {
+        return '*';
+      }).post('/api/upload', '*').reply(200, this.successResponse);
+
+      this.instance = _reactDom2.default.render(_react2.default.createElement(
+        UploadManager,
+        {
+          uploadUrl: this.uploadPath,
+          onUploadStart: this.onUploadStart,
+          onUploadProgress: this.onUploadProgress,
+          onUploadEnd: this.onUploadEnd
+        },
+        this.children
+      ), this.container);
+      this.errorResponse = { success: false, errors: { message: 'not found' } };
+      this.successResponse = { success: true };
+    });
+
+    afterEach(function () {
+      _nock2.default.cleanAll();
+      _nock2.default.enableNetConnect();
+    });
+
+    it('should call onUploadStart prop functions if it is given', function test() {
+      this.instance.upload(this.instance.props.uploadUrl, {});
+      expect(this.onUploadStart).toBeCalledWith({ status: uploadStatus.UPLOADING });
+    });
+  });
+});

--- a/lib/constants/status.js
+++ b/lib/constants/status.js
@@ -1,0 +1,11 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = {
+  FAILED: -1,
+  PENDING: 0,
+  UPLOADING: 1,
+  UPLOADED: 2
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.status = exports.UploadHandler = exports.UploadManager = exports.Receiver = undefined;
+
+var _Receiver = require('./Receiver');
+
+var _Receiver2 = _interopRequireDefault(_Receiver);
+
+var _UploadManager = require('./UploadManager');
+
+var _UploadManager2 = _interopRequireDefault(_UploadManager);
+
+var _UploadHandler = require('./UploadHandler');
+
+var _UploadHandler2 = _interopRequireDefault(_UploadHandler);
+
+var _status = require('./constants/status');
+
+var _status2 = _interopRequireDefault(_status);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.Receiver = _Receiver2.default;
+exports.UploadManager = _UploadManager2.default;
+exports.UploadHandler = _UploadHandler2.default;
+exports.status = _status2.default;

--- a/src/UploadManager.js
+++ b/src/UploadManager.js
@@ -44,22 +44,27 @@ class UploadManager extends Component {
             onUploadStart(assign(file, {status: uploadStatus.UPLOADING}));
         }
 
-        let data;
+        let data, type;
         if (!!field) {
             const formData = new FormData();
             formData.append(field, file);
             data = formData;
         } else {
             data = file;
+            type = file.type;
         }
         debug(`start uploading file#${file.id} to ${url}`, file);
 
-        request
+        let req = request
             [method.toLowerCase()](url)
             .accept(accept)
-            .set(uploadHeader)
-            .type(file.type)
-            .send(data)
+            .set(uploadHeader);
+
+        if (!!type) {
+            req = req.type(file.type);
+        }
+
+        req.send(data)
             .on('progress', ({percent}) => {
                 if (typeof onUploadProgress === 'function') {
                     onUploadProgress(assign(file, {

--- a/src/UploadManager.js
+++ b/src/UploadManager.js
@@ -35,6 +35,7 @@ class UploadManager extends Component {
       onUploadProgress,
       uploadErrorHandler,
       uploadHeader = {},
+      method,
     } = this.props;
 
     if (typeof onUploadStart === 'function') {
@@ -47,7 +48,7 @@ class UploadManager extends Component {
     debug(`start uploading file#${file.id} to ${url}`, file);
 
     request
-      .post(url)
+      [method.toLowerCase()](url)
       .accept('application/json')
       .set(uploadHeader)
       .send(formData)
@@ -110,10 +111,12 @@ UploadManager.propTypes = {
   uploadErrorHandler: PropTypes.func.isRequired,
   uploadUrl: PropTypes.string.isRequired,
   uploadHeader: PropTypes.object,
+  method: PropTypes.string,
 };
 
 UploadManager.defaultProps = {
   component: 'ul',
+  method: 'post',
   uploadErrorHandler: (err, res) => {
     let error = null;
     const body = clone(res.body);

--- a/src/UploadManager.js
+++ b/src/UploadManager.js
@@ -36,13 +36,22 @@ class UploadManager extends Component {
             uploadErrorHandler,
             uploadHeader = {},
             method,
-            accept
+            accept,
+            field,
         } = this.props;
 
         if (typeof onUploadStart === 'function') {
             onUploadStart(assign(file, {status: uploadStatus.UPLOADING}));
         }
 
+        let data;
+        if (!!field) {
+            const formData = new FormData();
+            formData.append(field, file);
+            data = formData;
+        } else {
+            data = file;
+        }
         debug(`start uploading file#${file.id} to ${url}`, file);
 
         request
@@ -50,7 +59,7 @@ class UploadManager extends Component {
             .accept(accept)
             .set(uploadHeader)
             .type(file.type)
-            .send(file)
+            .send(data)
             .on('progress', ({percent}) => {
                 if (typeof onUploadProgress === 'function') {
                     onUploadProgress(assign(file, {
@@ -112,12 +121,14 @@ UploadManager.propTypes = {
     uploadHeader: PropTypes.object,
     method: PropTypes.string,
     accept: PropTypes.string,
+    field: PropTypes.string,
 };
 
 UploadManager.defaultProps = {
     component: 'ul',
     method: 'post',
     accept: 'application/json',
+    field: 'file',
     uploadErrorHandler: (err, res) => {
         let error = null;
         const body = clone(res.body);

--- a/src/UploadManager.js
+++ b/src/UploadManager.js
@@ -1,136 +1,137 @@
-import React, { Component, PropTypes, cloneElement } from 'react';
-import invariant from 'invariant';
-import classNames from 'classnames';
-import assign from 'lodash/assign';
-import bindKey from 'lodash/bindKey';
-import clone from 'lodash/clone';
-import request from 'superagent';
-import uploadStatus from './constants/status';
+import React, {Component, PropTypes, cloneElement} from "react";
+import invariant from "invariant";
+import classNames from "classnames";
+import assign from "lodash/assign";
+import bindKey from "lodash/bindKey";
+import clone from "lodash/clone";
+import request from "superagent";
+import uploadStatus from "./constants/status";
 
 const debug = require('debug')('react-file-upload:UploadManager');
 
 class UploadManager extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.upload = this.upload.bind(this);
-  }
-
-  componentDidMount() {
-    invariant(
-      !!this.props.uploadUrl,
-      'Upload end point must be provided to upload files'
-    );
-
-    invariant(
-      !!this.props.onUploadEnd,
-      'onUploadEnd function must be provided'
-    );
-  }
-
-  upload(url, file) {
-    const {
-      onUploadStart,
-      onUploadEnd,
-      onUploadProgress,
-      uploadErrorHandler,
-      uploadHeader = {},
-      method,
-    } = this.props;
-
-    if (typeof onUploadStart === 'function') {
-      onUploadStart(assign(file, { status: uploadStatus.UPLOADING }));
+        this.upload = this.upload.bind(this);
     }
 
-    const formData = new FormData();
-    formData.append('file', file);
+    componentDidMount() {
+        invariant(
+            !!this.props.uploadUrl,
+            'Upload end point must be provided to upload files'
+        );
 
-    debug(`start uploading file#${file.id} to ${url}`, file);
+        invariant(
+            !!this.props.onUploadEnd,
+            'onUploadEnd function must be provided'
+        );
+    }
 
-    request
-      [method.toLowerCase()](url)
-      .accept('application/json')
-      .set(uploadHeader)
-      .send(formData)
-      .on('progress', ({ percent }) => {
-        if (typeof onUploadProgress === 'function') {
-          onUploadProgress(assign(file, {
-            progress: percent,
-            status: uploadStatus.UPLOADING,
-          }));
-        }
-      })
-      .end((err, res) => {
-        const { error, result } = uploadErrorHandler(err, res);
+    upload(url, file) {
+        const {
+            onUploadStart,
+            onUploadEnd,
+            onUploadProgress,
+            uploadErrorHandler,
+            uploadHeader = {},
+            method,
+            accept
+        } = this.props;
 
-        if (error) {
-          debug('failed to upload file', error);
-
-          if (typeof onUploadEnd === 'function') {
-            onUploadEnd(assign(file, { error, status: uploadStatus.FAILED }));
-          }
-
-          return;
+        if (typeof onUploadStart === 'function') {
+            onUploadStart(assign(file, {status: uploadStatus.UPLOADING}));
         }
 
-        debug('succeeded to upload file', res);
+        debug(`start uploading file#${file.id} to ${url}`, file);
 
-        if (typeof onUploadEnd === 'function') {
-          onUploadEnd(assign(file, { result, status: uploadStatus.UPLOADED }));
-        }
-      });
-  }
+        request
+            [method.toLowerCase()](url)
+            .accept(accept)
+            .set(uploadHeader)
+            .type(file.type)
+            .send(file)
+            .on('progress', ({percent}) => {
+                if (typeof onUploadProgress === 'function') {
+                    onUploadProgress(assign(file, {
+                        progress: percent,
+                        status: uploadStatus.UPLOADING,
+                    }));
+                }
+            })
+            .end((err, res) => {
+                const {error, result} = uploadErrorHandler(err, res);
 
-  render() {
-    const { component, customClass, style, children, uploadUrl } = this.props;
+                if (error) {
+                    debug('failed to upload file', error);
 
-    return React.createElement(
-      component,
-      { className: classNames(customClass), style },
-      React.Children.map(children, child => cloneElement(child, assign({
-        upload: bindKey(this, 'upload', uploadUrl, child.props.file),
-      }, child.props)))
-    );
-  }
+                    if (typeof onUploadEnd === 'function') {
+                        onUploadEnd(assign(file, {error, status: uploadStatus.FAILED}));
+                    }
+
+                    return;
+                }
+
+                debug('succeeded to upload file', res);
+
+                if (typeof onUploadEnd === 'function') {
+                    onUploadEnd(assign(file, {result, status: uploadStatus.UPLOADED}));
+                }
+            });
+    }
+
+    render() {
+        const {component, customClass, style, children, uploadUrl} = this.props;
+
+        return React.createElement(
+            component,
+            {className: classNames(customClass), style},
+            React.Children.map(children, child => cloneElement(child, assign({
+                upload: bindKey(this, 'upload', uploadUrl, child.props.file),
+            }, child.props)))
+        );
+    }
 }
 
 UploadManager.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]),
-  component: PropTypes.string.isRequired,
-  customClass: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
-  onUploadStart: PropTypes.func,
-  onUploadProgress: PropTypes.func,
-  onUploadEnd: PropTypes.func.isRequired,
-  style: PropTypes.object,
-  uploadErrorHandler: PropTypes.func.isRequired,
-  uploadUrl: PropTypes.string.isRequired,
-  uploadHeader: PropTypes.object,
-  method: PropTypes.string,
+    children: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.arrayOf(PropTypes.element),
+    ]),
+    component: PropTypes.string.isRequired,
+    customClass: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+    ]),
+    onUploadStart: PropTypes.func,
+    onUploadProgress: PropTypes.func,
+    onUploadEnd: PropTypes.func.isRequired,
+    style: PropTypes.object,
+    uploadErrorHandler: PropTypes.func.isRequired,
+    uploadUrl: PropTypes.string.isRequired,
+    uploadHeader: PropTypes.object,
+    method: PropTypes.string,
+    accept: PropTypes.string,
 };
 
 UploadManager.defaultProps = {
-  component: 'ul',
-  method: 'post',
-  uploadErrorHandler: (err, res) => {
-    let error = null;
-    const body = clone(res.body);
+    component: 'ul',
+    method: 'post',
+    accept: 'application/json',
+    uploadErrorHandler: (err, res) => {
+        let error = null;
+        const body = clone(res.body);
 
-    if (err) {
-      error = err.message;
-    } else if (body && body.errors) {
-      error = body.errors;
-    }
+        if (err) {
+            error = err.message;
+        } else if (body && body.errors) {
+            error = body.errors;
+        }
 
-    delete body.errors;
+        delete body.errors;
 
-    return { error, result: body };
-  },
+        return {error, result: body};
+    },
 };
 
 export default UploadManager;


### PR DESCRIPTION
i was testing your component with azure cloud Shared Access Signature (SAS) and i faced some problems and i solved them as follow: 
1- add `method` property default as `post`, some cloud storage required put instead of post
2- add `accept` property default as`application/json`, if response doesn't return json for example using cloud SAS this property can cause a problem
3- add `field` name property default to `file`, when user use cloud SAS user can set property to null to send the file without form 
4- set request `type` from `file.type` 