### PR TITLE
Use the prop-types library

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jest-cli": "*",
     "jsdom": "^7.0.2",
     "nock": "^8.0.0",
+    "prop-types": "^15.5.10",
     "react-addons-test-utils": "^0.14.8 || ^15.0.0",
     "react-dom": "^0.14.8 || ^15.0.0"
   },

--- a/src/Receiver.js
+++ b/src/Receiver.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import classNames from 'classnames';
 import shortid from 'shortid';

--- a/src/UploadHandler.js
+++ b/src/UploadHandler.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import uploadStatus from './constants/status';
 

--- a/src/UploadManager.js
+++ b/src/UploadManager.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, cloneElement } from 'react';
+import React, { Component, cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import classNames from 'classnames';
 import assign from 'lodash/assign';


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated from React v15.5: https://facebook.github.io/react/docs/typechecking-with-proptypes.html