### PR TITLE
Version v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ react-file-uploader is a set of customizable React components that helps you to 
 
 It is expected to be production ready from v1.0.0, although v0.4.1 provides a stable but very simple and limited usage.
 
-It is worth to mention the default uploading implementation in `UploadManager` is biased with FormData, which is not configurable at this moment.
+The uploading implementation is coupled with [superagent](https://visionmedia.github.io/superagent/), and the `method`, `header` and `data` are configurable with props.
 
 ## Installation
 
@@ -31,7 +31,7 @@ this module currently contains 4 major entities, which are
 import { Receiver } from 'react-file-uploader';
 
 <Receiver
-	wrapperId={STRING}
+  wrapperId={STRING}
   customClass={STRING_OR_ARRAY}
   style={OBJECT}
   isOpen={BOOLEAN}
@@ -40,9 +40,9 @@ import { Receiver } from 'react-file-uploader';
   onDragLeave={FUNCTION}
   onFileDrop={FUNCTION}
 >
-    <div>
-      visual layer of the receiver (drag & drop panel)
-    </div>
+  <div>
+    visual layer of the receiver (drag & drop panel)
+  </div>
 </Receiver>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # react-file-uploader
 
-react-file-uploader is a set of highly customizable React components that helps you to build a file uploader in your application easily. 
+react-file-uploader is a set of customizable React components that helps you to build a file uploader in your application easily.
 
-react-file-uploader is not production ready because it is not fully tested on all browsers, and the unit test coverage is just not good enough. However, it has been used in my cms project since v0.3.0.
+It is expected to be production ready from v1.0.0, although v0.4.1 provides a stable but very simple and limited usage.
+
+It is worth to mention the default uploading implementation in `UploadManager` is biased with FormData, which is not configurable at this moment.
 
 ## Installation
 
@@ -307,6 +309,7 @@ UPLOADED = 2
 
 * complete test cases
 * add real-world example
+* verify and provide better support to Amazon Simple Storage Service
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ import { UploadManager } from 'react-file-uploader';
 <UploadManager
   component={STRING}
   customClass={STRING_OR_ARRAY}
-  formDataParser={FUNCTION}
   onUploadAbort={FUNCTION}
   onUploadStart={FUNCTION}
   onUploadProgress={FUNCTION}
@@ -128,8 +127,9 @@ import { UploadManager } from 'react-file-uploader';
   progressDebounce={NUMBER}
   reqConfigs={OBJECT}
   style={OBJECT}
+  uploadDataHandler={FUNCTION}
   uploadErrorHandler={FUNCTION}
-  uploadHeader={OBJECT}
+  uploadHeaderHandler={FUNCTION}
 	uploadUrl={STRING}
 >
 	// UploadHandler as children
@@ -145,19 +145,7 @@ import { UploadManager } from 'react-file-uploader';
 
 * component - `string`: the DOM tag name of the wrapper. By default it is an unordered list `ul`.
 * customClass - `string | array`: the class name(s) for the wrapper
-* formDataParser - `function`: the parser function of the form data to be send through the upload request.
-
-```
-/**
- * @param formData {FormData} FormData instance
- * @param fileData {File Object} File data object
- * @returns {FormData} decorated FormData instance
- */
-let formDataParser = (formData, fileData) => {
-	formData.append('file', fileData);
-	return formData;
-}
-```
+* formDataParser - **DEPRECATED** this prop function is renamed as `uploadDataHandler` starting from v1.0.0.
 
 * onUploadAbort - `function`: this will be fired when the upload request is aborted. This function is available from v1.0.0.
 
@@ -212,7 +200,21 @@ let onUploadEnd = (fileId, { error, progress, result, status }) => { ... }
 * reqConfigs - `object`: the exposed superagent configs including `accept`, `method`, `timeout` and `withCredentials`.
 * style - `object`: the style property for the wrapper.
 * uploadUrl - `string` `required`: the url of the upload end point from your server.
-* uploadHeader - `object`: the header object to be set as request header.
+* uploadDataHandler - `function`: this function is to parse the data to be sent as request data. From v1.0.0, the first argument will become a upload task object instead of the File instance.
+
+```
+let uploadDataHandler = (upload) => {
+	// for FormData
+	const formData = new FormData();
+	formData.append('file', upload.data);
+	formData.append('custom-key', 'custom-value');
+	return formData;
+
+	// for AWS S3
+	return upload.data;
+}
+```
+
 * uploadErrorHandler - `function`: this function is to process the arguments of `(err, res)` in `superagent.end()`. In this function, you can resolve the error and result according to your upload api response. Default implementation is available as defaultProps.
 
 ```
@@ -229,6 +231,20 @@ function uploadErrorHandler(err, res) {
 	delete body.errors;
 
 	return { error, result: body };
+}
+```
+
+* uploadHeader - **DEPRECATED** this prop is deprecated and replaced by `uploadHeaderHandler`.
+
+* uploadHeaderHandler - `function`: the function is to parse the header object to be sent as request header.
+
+```
+let uploadHeaderHandler = (upload) => {
+	// for AWS S3
+	return {
+		'Content-Type': upload.data.type,
+		'Content-Disposition': 'inline'
+	};
 }
 ```
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,7 +7,6 @@
     "connect-multiparty": "^2.0.0",
     "express": "^4.13.3",
     "forever": "^0.15.1",
-    "lodash": "^4.13.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-file-uploader",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "A set of file-upload-components with React.js.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Receiver.js
+++ b/src/Receiver.js
@@ -87,28 +87,30 @@ class Receiver extends Component {
   }
 
   onFileDrop(e) {
-    // eslint-disable-next-line no-param-reassign
-    e = e || window.event;
     e.preventDefault();
 
-    const files = [];
+    const uploads = [];
 
-    if (e.dataTransfer) {
-      const fileList = e.dataTransfer.files || [];
+    if (e.dataTransfer && e.dataTransfer.files) {
+      const fileList = e.dataTransfer.files;
 
       for (let i = 0; i < fileList.length; i++) {
-        fileList[i].id = shortid.generate();
-        fileList[i].status = status.PENDING;
-        fileList[i].progress = 0;
-        fileList[i].src = null;
-        files.push(fileList[i]);
+        const upload = {
+          id: shortid.generate(),
+          status: status.PENDING,
+          progress: 0,
+          src: null,
+          data: fileList[i]
+        };
+
+        uploads.push(upload);
       }
     }
 
     // reset drag level once dropped
     this.setState({ dragLevel: 0 });
 
-    this.props.onFileDrop(e, files);
+    this.props.onFileDrop(e, uploads);
   }
 
   render() {

--- a/src/Receiver.js
+++ b/src/Receiver.js
@@ -31,12 +31,14 @@ class Receiver extends Component {
     const { wrapperId } = this.props;
 
     if (wrapperId) {
+      const wrapperElement = document.getElementById(wrapperId);
+
       invariant(
-        !!document.getElementById(wrapperId),
+        !!wrapperElement,
         `wrapper element with Id ${wrapperId} not found.`
       );
 
-      this.wrapper = document.getElementById(wrapperId);
+      this.wrapper = wrapperElement;
     }
 
     this.wrapper.addEventListener('dragenter', this.onDragEnter);

--- a/src/UploadHandler.js
+++ b/src/UploadHandler.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import invariant from 'invariant';
 import classNames from 'classnames';
 import uploadStatus from './constants/status';
 
@@ -9,47 +10,40 @@ class UploadHandler extends Component {
   componentDidMount() {
     const { file, upload, autoStart } = this.props;
 
+    invariant(
+      typeof upload === 'function',
+      '`props.upload` must be a function'
+    );
+
+    invariant(
+      !!file,
+      '`props.file` must be provided'
+    );
+
     if (file.status === uploadStatus.PENDING && autoStart) {
       debug('autoStart in on, calling upload()');
       upload(file);
     }
   }
 
-  getStatusString(status) {
-    switch (status) {
-      case -1:
-        return 'failed';
-
-      case 0:
-        return 'pending';
-
-      case 1:
-        return 'uploading';
-
-      case 2:
-        return 'uploaded';
-
-      default:
-        return '';
-    }
-  }
-
   render() {
-    const { component, customClass, style } = this.props;
+    const { abort, component, customClass, style, upload } = this.props;
 
     return React.createElement(
       component,
       { className: classNames(customClass), style },
-      this.props.children
+      typeof this.props.children === 'function' ? this.props.children({ upload, abort }, this) : this.props.children
     );
   }
 }
 
 UploadHandler.propTypes = {
+  abort: PropTypes.func.isRequired,
   autoStart: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
+    PropTypes.func,
   ]),
   component: PropTypes.string.isRequired,
   customClass: PropTypes.oneOfType([
@@ -58,7 +52,7 @@ UploadHandler.propTypes = {
   ]),
   file: PropTypes.object.isRequired,
   style: PropTypes.object,
-  upload: PropTypes.func,
+  upload: PropTypes.func.isRequired,
 };
 
 UploadHandler.defaultProps = {

--- a/src/__tests__/UploadHandler-test.js
+++ b/src/__tests__/UploadHandler-test.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-undef, max-len, no-console */
+jest.dontMock('../UploadHandler');
+jest.dontMock('../index');
+jest.dontMock('classnames');
+
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+const FileUploader = require('../index');
+const uploadStatus = FileUploader.status;
+const UploadHandler = FileUploader.UploadHandler;
+
+configure({ adapter: new Adapter() });
+
+describe('UploadHandler', () => {
+  let uploadHandler,
+    component,
+    mockAbort,
+    mockUpload,
+    stringClass = 'receiver',
+    arrayClass = ['react', 'receiver'],
+    customStyle = { display: 'block' },
+    children = (<span>children</span>),
+    renderFunction = jest.genMockFn(),
+    file = { id: 'fileId', status: uploadStatus.PENDING };
+
+  beforeEach(() => {
+    mockAbort = jest.genMockFn();
+    mockUpload = jest.genMockFn();
+    renderFunction.mockReturnValue(children);
+
+    component = (
+      <UploadHandler
+        customClass={stringClass}
+        style={customStyle}
+        file={file}
+        abort={mockAbort}
+        upload={mockUpload}
+      />
+    );
+
+    uploadHandler = shallow(component);
+  });
+
+  describe('componentDidMount()', () => {
+    it('should throw an error if `props.upload` is not a function', () => {
+      expect(() => shallow(
+        <UploadHandler
+          file={file}
+          abort={mockAbort}
+        />
+      )).toThrow('`props.upload` must be a function');
+    });
+
+    it('should throw an error if `props.file` is missing', () => {
+      expect(() => shallow(
+        <UploadHandler
+          abort={mockAbort}
+          upload={mockUpload}
+        />
+      )).toThrow('`props.file` must be provided');
+    });
+
+    it('should call `props.upload()` if `props.autoStart` is true', () => {
+      uploadHandler = shallow(
+        <UploadHandler
+          file={file}
+          upload={mockUpload}
+          autoStart
+        />
+      );
+
+      expect(mockUpload).toBeCalledWith(file);
+    });
+  });
+
+  describe('render()', () => {
+    it('should render a HTML `props.component` element as wrapper', () => {
+      expect(uploadHandler.type()).toEqual('li');
+      uploadHandler.setProps({ component: 'div' });
+      expect(uploadHandler.type()).toEqual('div');
+      expect(uploadHandler.children().exists()).toBe(false);
+    });
+
+    it('should render ReactElement children if it is given', () => {
+      uploadHandler.setProps({ children });
+      expect(uploadHandler.children().matchesElement(children));
+    });
+
+    it('should accept children as render function with { abort, upload } and the instance itself', () => {
+      uploadHandler.setProps({ children: renderFunction });
+      expect(renderFunction).toBeCalledWith({ abort: mockAbort, upload: mockUpload }, uploadHandler.instance());
+      expect(uploadHandler.children().matchesElement(children));
+    });
+
+    it('should render a div wrapper with customClass in string', () => {
+      uploadHandler.setProps({ customClass: stringClass });
+      expect(uploadHandler.hasClass(stringClass)).toBe(true);
+    });
+
+    it('should render a div wrapper with customClass in array', () => {
+      uploadHandler.setProps({ customClass: arrayClass });
+      arrayClass.forEach((classname) => {
+        expect(uploadHandler.hasClass(classname)).toBe(true);
+      });
+    });
+
+    it('should render a div wrapper with applying `props.style`', () => {
+      uploadHandler.setProps({ style: customStyle });
+      expect(uploadHandler.prop('style')).toEqual(customStyle);
+    });
+  });
+});
+/* eslint-enable no-undef, max-len, no-console */

--- a/src/constants/status.js
+++ b/src/constants/status.js
@@ -1,4 +1,5 @@
 export default {
+  ABORTED: -2,
   FAILED: -1,
   PENDING: 0,
   UPLOADING: 1,


### PR DESCRIPTION
### Proposed Version: v1.0.0

### Receiver
* **[BREAKING]** prevented mutating the file data object `e.dataTransfer.files`, and creates upload object instead. File Object is now assigned and preserved with property of "data" inside the upload object.

```
second argument in this.props.onFileDrop:

// v0.3.x
files = [
  {
    id: string,
    status: number,
    prgroess: number,
    src: string,
    lastModified: number,
    lastModifiedDate: string,
    name: string,
    size: number,
    type: string,
    webkitRelativePath: string,
  },
  ...
];

// v1.0.0
uploads = [
  {
    id: string,
    status: number,
    prgroess: number,
    src: string,
    // File Object moved into data property
    data: {
      lastModified: number,
      lastModifiedDate: string,
      name: string,
      size: number,
      type: string,
      webkitRelativePath: string,
    },
  },
  ...
];
```

### UploadHandler
* checks for the existence of `props.upload` and `props.file` in `componentDidMount`
* removed unused `getStatusString` function
* allows render function as `children` to provide `abort` and `upload` function

### UploadManager
* **[BREAKING]** baked-in with debounced on progress callback, accepts `props.progressDebounce` for configuration
* **[BREAKING]** prevented mutating the file data object in `onUploadProgress` and `onUploadEnd`
* **[BREAKING]** for `onUploadAbort`, `onUploadStart`, `onUploadProgress` and `onUploadEnd`, the first argument now becomes just the file (upload task) id but not the file object. It minimise the chance of File object mutation from the callback.
* **[BREAKING]** `props.formDataParser` is **DEPRECATED** and replaced by `props.uploadDataHandler`
* **[BREAKING]** `props.uploadHeader` is **DEPRECATED** and replaced by `props.uploadHeaderHandler`
* supports `abort` function to an upload task and accepts `props.onUploadAbort` callback

```
// v0.3.x
this.props.onUploadStart = (file, { progress, status }) => { ... };
// v1.0.0
this.props.onUploadStart = (fileId, { progress, status }) => { ... };
```

### General
* added more unit test coverage, some are still missing in `UploadManager`
* updated basic example to cope with the breaking changes